### PR TITLE
Fix handling torrents with sizes less that 1K

### DIFF
--- a/tpblite/models/torrents.py
+++ b/tpblite/models/torrents.py
@@ -5,11 +5,10 @@ import lxml.etree as ET
 def fileSizeStrToInt(size_str):
     """Converts file size given in *iB format to bytes integer"""
 
-    unit_dict = {"KiB": (2 ** 10), "MiB": (2 ** 20), "GiB": (2 ** 30), "TiB": (2 ** 40)}
+    unit_dict = {"B": 1, "KiB": (2 ** 10), "MiB": (2 ** 20), "GiB": (2 ** 30), "TiB": (2 ** 40)}
     try:
-        num = float(size_str[:-3])
-        unit = size_str[-3:]
-        return int(num * unit_dict[unit])
+        (num, unit) = size_str.split()
+        return int(float(num) * unit_dict[unit])
     except Exception as e:
         raise AttributeError(
             "Cannot determine filesize: {0}, error: {1}".format(size_str, e)


### PR DESCRIPTION
This patch fixes a bug in handling torrents that are smaller that 1KB (for example some text files etc). Here's an example of a crash before the patch:

```
Traceback (most recent call last):
  File "/usr/home/filipp/.env/lib/python3.8/site-packages/tpblite/models/torrents.py", line 12, in fileSizeStrToInt
    return int(num * unit_dict[unit])
KeyError: '6 B'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./search-torrent", line 9, in <module>
    torrents = t.search(sys.argv[1])
  File "/usr/home/filipp/.env/lib/python3.8/site-packages/tpblite/tpblite.py", line 43, in search
    return Torrents(q.html_source)
  File "/usr/home/filipp/.env/lib/python3.8/site-packages/tpblite/models/torrents.py", line 90, in __init__
    self.list = self._createTorrentList()
  File "/usr/home/filipp/.env/lib/python3.8/site-packages/tpblite/models/torrents.py", line 114, in _createTorrentList
    torrents.append(Torrent(row))
  File "/usr/home/filipp/.env/lib/python3.8/site-packages/tpblite/models/torrents.py", line 34, in __init__
    ) = self._getFileInfo()
  File "/usr/home/filipp/.env/lib/python3.8/site-packages/tpblite/models/torrents.py", line 64, in _getFileInfo
    byte_size = fileSizeStrToInt(size)
  File "/usr/home/filipp/.env/lib/python3.8/site-packages/tpblite/models/torrents.py", line 14, in fileSizeStrToInt
    raise AttributeError(
AttributeError: Cannot determine filesize: 916 B, error: '6 B'
```