### PR TITLE
Add infohash attrribute in Torrent object

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You can see how many `Torrent` objects your query has returned, by using the `le
 - `Torrent.url` - URL of the torrent page (str)
 - `Torrent.is_trusted` - Whether the torrent is from a trusted source.
 - `Torrent.is_vip` - Whether the torrent is from a VIP source.
+- `Torrent.infohash` - The info hash of the torrent (str)
 
 Example Workflow
 ==========

--- a/tpblite/models/torrents.py
+++ b/tpblite/models/torrents.py
@@ -1,3 +1,4 @@
+import re
 import unicodedata
 import lxml.etree as ET
 
@@ -35,6 +36,7 @@ class Torrent:
         self.url = self._getUrl()
         self.is_vip = self._getVip()
         self.is_trusted = self._getTrusted()
+        self.infohash = self._getInfohash(self.magnetlink)
 
     def __str__(self):
         return "{0}, S: {1}, L: {2}, {3}".format(
@@ -75,7 +77,10 @@ class Torrent:
     def _getTrusted(self):
         image_name = self.html_row.xpath('.//img/@src')[1]
         return 'trusted' in image_name
-
+    
+    def _getInfohash(self, magnetLink):
+        infoHash = re.search(r'btih:(.*?)&dn', magnetLink)
+        return infoHash.group(1) if infoHash else None
 
 class Torrents:
     """


### PR DESCRIPTION
Add infohash attr to get the info hash of a torrent.

Usage:

```
>> torrent = t.search('naruto')
>> torrent[0].infohash
'2ECD15BEED3C58DF6289DAA8813D80022D715176'
```